### PR TITLE
chore: add modulePaths jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   roots: ['<rootDir>/src'],
+  modulePaths: ["<rootDir>/src"],
   collectCoverageFrom: [
     '<rootDir>/src/**/*.{ts,tsx}',
     '!<rootDir>/src/main/**/*',


### PR DESCRIPTION
Adicionando essa configuração os arquivos de testes (.spec.ts) param de dar erro ao usar o caminho relativo inserido pelo auto import, este problema existe apenas nos mesmos.